### PR TITLE
Update file path to be unified all platforms

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1,5 +1,6 @@
 var fs   = Npm.require('fs');
 var less = Npm.require('less');
+var path = Npm.require('path');
 var LessPluginAutoPrefix = Npm.require('less-plugin-autoprefix');
 
 var DEFAULT_INDEX_FILE_PATH = "./client/main.less";
@@ -25,6 +26,9 @@ var loadJSONFile = function (compileStep, filePath) {
   }
 };
 
+var convertToPosixPath = function(filePath) {
+  return filePath.split(path.sep).join('/');
+};
 
 Plugin.registerSourceHandler("less", {archMatching: 'web'}, function (compileStep) {
   // Reading in user configuration
@@ -37,14 +41,14 @@ Plugin.registerSourceHandler("less", {archMatching: 'web'}, function (compileSte
   if ( config.useIndex ) {
     var indexFilePath = config.indexFilePath || DEFAULT_INDEX_FILE_PATH;
     // If this isn't the index file, add it to the index if need be
-    if ( compileStep.inputPath != indexFilePath ) {
+    if ( convertToPosixPath(compileStep.inputPath) != indexFilePath ) {
       if ( fs.existsSync(indexFilePath) ) {
         var lessIndex = fs.readFileSync(indexFilePath, 'utf8');
-        if ( lessIndex.indexOf(compileStep.inputPath) == -1 ) {
-          fs.appendFileSync(indexFilePath, '\n@import "' + compileStep.inputPath + '";', 'utf8');
+        if ( lessIndex.indexOf(convertToPosixPath(compileStep.inputPath)) == -1 ) {
+          fs.appendFileSync(indexFilePath, '\n@import "' + convertToPosixPath(compileStep.inputPath) + '";', 'utf8');
         }
       } else {
-        var newFile = generatedMessage + '@import "' + compileStep.inputPath + '";\n';
+        var newFile = generatedMessage + '@import "' + convertToPosixPath(compileStep.inputPath) + '";\n';
         fs.writeFileSync(indexFilePath, newFile, 'utf8');
       }
       return; // stop here, only compile the index file

--- a/plugin.js
+++ b/plugin.js
@@ -42,7 +42,7 @@ Plugin.registerSourceHandler("less", {archMatching: 'web'}, function (compileSte
     var indexFilePath = config.indexFilePath || DEFAULT_INDEX_FILE_PATH,
         posixInputPath = convertToPosixPath(compileStep.inputPath);
     // If this isn't the index file, add it to the index if need be
-    if ( posixInputPath) != indexFilePath ) {
+    if ( posixInputPath != indexFilePath ) {
       if ( fs.existsSync(indexFilePath) ) {
         var lessIndex = fs.readFileSync(indexFilePath, 'utf8');
         if ( lessIndex.indexOf(posixInputPath) == -1 ) {

--- a/plugin.js
+++ b/plugin.js
@@ -39,16 +39,17 @@ Plugin.registerSourceHandler("less", {archMatching: 'web'}, function (compileSte
 
   // Load order setup
   if ( config.useIndex ) {
-    var indexFilePath = config.indexFilePath || DEFAULT_INDEX_FILE_PATH;
+    var indexFilePath = config.indexFilePath || DEFAULT_INDEX_FILE_PATH,
+        posixInputPath = convertToPosixPath(compileStep.inputPath);
     // If this isn't the index file, add it to the index if need be
-    if ( convertToPosixPath(compileStep.inputPath) != indexFilePath ) {
+    if ( posixInputPath) != indexFilePath ) {
       if ( fs.existsSync(indexFilePath) ) {
         var lessIndex = fs.readFileSync(indexFilePath, 'utf8');
-        if ( lessIndex.indexOf(convertToPosixPath(compileStep.inputPath)) == -1 ) {
-          fs.appendFileSync(indexFilePath, '\n@import "' + convertToPosixPath(compileStep.inputPath) + '";', 'utf8');
+        if ( lessIndex.indexOf(posixInputPath) == -1 ) {
+          fs.appendFileSync(indexFilePath, '\n@import "' + posixInputPath + '";', 'utf8');
         }
       } else {
-        var newFile = generatedMessage + '@import "' + convertToPosixPath(compileStep.inputPath) + '";\n';
+        var newFile = generatedMessage + '@import "' + posixInputPath + '";\n';
         fs.writeFileSync(indexFilePath, newFile, 'utf8');
       }
       return; // stop here, only compile the index file


### PR DESCRIPTION
The less reference defines path separators to be / while on windows the paths were separated by \ in the generated less file. With this adjustments every \ from the file paths will be replaced with / in the relevant locations.
